### PR TITLE
ci: sync-demo

### DIFF
--- a/.github/workflows/sync-config.yml
+++ b/.github/workflows/sync-config.yml
@@ -1,0 +1,11 @@
+sync:
+  - source: graphgen
+    dest: graphgen
+  - source: resources
+    dest: resources
+  - source: webui
+    dest: webui
+  - source: webui/app.py
+    dest: app.py
+  - source: requirements.txt
+    dest: requirements.txt

--- a/.github/workflows/sync-demo.yml
+++ b/.github/workflows/sync-demo.yml
@@ -1,0 +1,54 @@
+name: Sync Demo Branch
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  sync-demo:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout main branch
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Checkout demo branch
+      uses: actions/checkout@v4
+      with:
+        ref: demo
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: demo
+
+    - name: Copy files using config
+      run: |
+        while IFS= read -r line; do
+          source=$(echo $line | cut -d: -f1 | xargs)
+          dest=$(echo $line | cut -d: -f2 | xargs)
+          
+          if [ -e "$source" ]; then
+            mkdir -p "demo/$(dirname $dest)"
+            cp -r "$source" "demo/$dest"
+            echo "Copied $source to $dest"
+          fi
+        done < <(grep -E '^\s*-\s+source:' .github/sync-config.yml | sed 's/.*source: //' | paste -d: - <(grep -E '^\s*-\s+dest:' .github/sync-config.yml | sed 's/.*dest: //'))
+
+    - name: Commit and push changes
+      run: |
+        cd demo
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        
+        # 检查是否有变化
+        if [[ -n $(git status --porcelain) ]]; then
+          git add .
+          git commit -m "Auto-sync demo branch with main branch"
+          git push origin demo
+          echo "Changes pushed to demo branch"
+        else
+          echo "No changes to sync"
+        fi


### PR DESCRIPTION
每次main分支更新时，构建可以直接用于创建gradio demo的demo分支，减少手动操作