### PR TITLE
fix: map yes/no synonyms to their probabilities and normalize

### DIFF
--- a/graphgen/models/llm/openai_client.py
+++ b/graphgen/models/llm/openai_client.py
@@ -105,8 +105,8 @@ class OpenAIClient(BaseLLMClient):
             kwargs["logprobs"] = True
             kwargs["top_logprobs"] = self.topk_per_token
 
-        # Limit max_tokens to 1 to avoid long completions
-        kwargs["max_tokens"] = 1
+        # Limit max_tokens to 5 to avoid long completions
+        kwargs["max_tokens"] = 5
 
         completion = await self.client.chat.completions.create(  # pylint: disable=E1125
             model=self.model_name, **kwargs


### PR DESCRIPTION
This PR replaces the old yes/no entropy loss with a synonym-aware version:
1. Adds exhaustive English + Chinese synonym lists for “yes” and “no”.
2. Introduces `_normalize_yes_no()` that pools probabilities of all synonyms and re-normalizes them to a clean {yes: p, no: 1-p} distribution.
3. Updates yes_no_loss_entropy() to use this normalized distribution instead of looking only at the top token, making the loss robust to wording variations.