### PR TITLE
workflow: add search_uniprot example

### DIFF
--- a/graphgen/configs/search_config.yaml
+++ b/graphgen/configs/search_config.yaml
@@ -1,7 +1,7 @@
 pipeline:
   - name: read
     params:
-      input_file:  resources/input_examples/search_demo.json # input file path, support json, jsonl, txt, pdf. See resources/input_examples for examples
+      input_file:  resources/input_examples/search_demo.jsonl # input file path, support json, jsonl, txt, pdf. See resources/input_examples for examples
 
   - name: search
     params:

--- a/scripts/search/search_uniprot.sh
+++ b/scripts/search/search_uniprot.sh
@@ -1,0 +1,3 @@
+python3 -m graphgen.run \
+--config_file graphgen/configs/search_config.yaml \
+--output_dir cache/


### PR DESCRIPTION
This PR adds a usage example for UniProt search and improves the concurrency handling of BLAST searches. 