### PR TITLE
Fix crash in ECEPartitioner caused by unsafe unpacking of frozenset edge keys

### DIFF
--- a/graphgen/models/partitioner/ece_partitioner.py
+++ b/graphgen/models/partitioner/ece_partitioner.py
@@ -142,7 +142,7 @@ class ECEPartitioner(BFSPartitioner):
             return Community(
                 id=seed_unit[1],
                 nodes=list(community_nodes.keys()),
-                edges=[(u, v) for (u, v), _ in community_edges.items()],
+                edges=[tuple(edge) for edge in community_edges if isinstance(edge, frozenset) and len(edge)==2],
             )
 
         for unit in tqdm(all_units, desc="ECE partition"):


### PR DESCRIPTION
### Title

Fix crash in ECEPartitioner caused by unsafe unpacking of frozenset edge keys

---

### Description

This PR fixes a runtime crash in `ECEPartitioner` that occurs during the `PartitionService` stage when constructing `Community` objects.

Internally, `ECEPartitioner` represents edges using `frozenset({u, v})`. However, the current implementation incorrectly assumes edge keys can be unpacked directly as `(u, v)` tuples, which may lead to a `ValueError` during execution.

This change makes edge conversion explicit and robust by safely converting `frozenset` edge keys into `(u, v)` tuples.

---

### Problem

The following code assumes edge keys are `(u, v)` tuples:

```python
edges=[(u, v) for (u, v), _ in community_edges.items()]
```

However, `community_edges` uses `frozenset({u, v})` as keys.
Unpacking a `frozenset` is unsafe and may raise:

```
ValueError: not enough values to unpack (expected 2, got 1)
```

This issue is more likely to surface when upstream stages (e.g. `JudgeService`) degrade edge metadata and malformed edge keys propagate downstream.

---

### Solution

* Explicitly convert `frozenset` edge keys into `(u, v)` tuples
* Skip malformed edge keys defensively
* Preserve existing ECE and BFS partitioning logic

---

### Impact

* ✅ Prevents `ECEPartitioner` from crashing during community construction
* ✅ Makes edge handling consistent with internal data representation
* ✅ Improves robustness without changing algorithm semantics

---

### Additional Notes

This fix addresses a structural inconsistency between internal edge representation and output construction logic.
No changes are made to sampling strategy, BFS expansion, or ECE computation.

---
