### PR TITLE
Fix missing runtime dependencies (pyarrow, kuzu)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,8 @@ aiohttp
 socksio
 pydantic
 ray==2.52.1
+kuzu
+pyarrow
 
 leidenalg
 igraph


### PR DESCRIPTION
## Problem

Running the following command fails at runtime due to missing dependencies:

```bash
bash examples/generate/generate_cot_qa/generate_cot.sh
```

### Error 1: missing `pyarrow`

```text
ModuleNotFoundError: No module named 'pyarrow'
  File "ray/data/_internal/util.py", line 33, in <module>
    import pyarrow
```

`ray.data` requires `pyarrow`, but it is not explicitly declared or checked, causing an import-time crash.

---

### Error 2: missing `kuzu`

```text
ImportError: KuzuDB is not installed. Please install it via `pip install kuzu`.
  File "graphgen/models/storage/graph/kuzu_storage.py", line 32, in __post_init__
```

This error occurs during `GraphStorageActor` initialization, after part of the pipeline has already started, leading to Ray actor failure.

---

## Fix

* Add `pyarrow` and `kuzu` to `requirements.txt` to resolve runtime import errors in `ray.data` and `GraphStorageActor`.

