### PR TITLE
fix: type conversion in vllm_wrapper

### DIFF
--- a/graphgen/models/llm/local/vllm_wrapper.py
+++ b/graphgen/models/llm/local/vllm_wrapper.py
@@ -24,7 +24,7 @@ class VLLMWrapper(BaseLLMWrapper):
         temperature = float(temperature)
         top_p = float(top_p)
         top_k = int(top_k)
-        
+
         super().__init__(temperature=temperature, top_p=top_p, top_k=top_k, **kwargs)
         try:
             from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams


### PR DESCRIPTION
This PR addresses potential type mismatches for critical parameters within the `vllm_wrapper`.