### PR TITLE
fix: Change the replacement symbol for masked entity

### DIFF
--- a/graphgen/models/generator/masked_fill_in_blank_generator.py
+++ b/graphgen/models/generator/masked_fill_in_blank_generator.py
@@ -115,7 +115,8 @@ class MaskedFillInBlankGenerator(BaseGenerator):
         match = re.search(mask_pattern, context)
         if match:
             gth = match.group(0)
-            masked_context = mask_pattern.sub("___", context)
+            # masked_context = mask_pattern.sub("___", context)
+            masked_context = mask_pattern.sub("{ }", context)
         else:
             logger.debug(
                 "Regex Match Failed!\n"

--- a/graphgen/models/generator/masked_fill_in_blank_generator.py
+++ b/graphgen/models/generator/masked_fill_in_blank_generator.py
@@ -115,7 +115,6 @@ class MaskedFillInBlankGenerator(BaseGenerator):
         match = re.search(mask_pattern, context)
         if match:
             gth = match.group(0)
-            # masked_context = mask_pattern.sub("___", context)
             masked_context = mask_pattern.sub("{ }", context)
         else:
             logger.debug(


### PR DESCRIPTION
K2V uses “{ }” to replace the masked entity. Although "___" is an alternative, using "{ }" is more consistent with the methodology described in the original paper.